### PR TITLE
Fix names for switches

### DIFF
--- a/hatasmota/switch.py
+++ b/hatasmota/switch.py
@@ -251,7 +251,7 @@ class TasmotaSwitchConfig(TasmotaAvailabilityConfig, TasmotaEntityConfig):
         return cls(
             endpoint="switch",
             idx=idx,
-            friendly_name=config_get_friendlyname(config, platform, idx),
+            friendly_name=config_get_switchname(config, idx),
             mac=config[CONF_MAC],
             platform=platform,
             poll_payload="10",

--- a/hatasmota/switch.py
+++ b/hatasmota/switch.py
@@ -36,7 +36,6 @@ from .entity import (
 )
 from .trigger import TasmotaTrigger
 from .utils import (
-    config_get_friendlyname,
     config_get_state_offline,
     config_get_state_online,
     config_get_state_power_off,


### PR DESCRIPTION
Use the names generated by `SwitchText` instead of the `FriendlyName` (for relays).