### PR TITLE
Add support for using tasmota's native wakeup feature

### DIFF
--- a/hatasmota/const.py
+++ b/hatasmota/const.py
@@ -18,6 +18,7 @@ COMMAND_SHUTTER_POSITION: Final = "ShutterPosition"
 COMMAND_SHUTTER_STOP: Final = "ShutterStop"
 COMMAND_SHUTTER_TILT: Final = "ShutterTilt"
 COMMAND_SPEED: Final = "Speed2"
+COMMAND_WAKEUP: Final = "Wakeup"
 COMMAND_WHITE: Final = "White"
 
 CONF_BUTTON: Final = "btn"

--- a/hatasmota/light.py
+++ b/hatasmota/light.py
@@ -16,6 +16,7 @@ from .const import (
     COMMAND_POWER,
     COMMAND_SCHEME,
     COMMAND_SPEED,
+    COMMAND_WAKEUP,
     COMMAND_WHITE,
     CONF_LIGHT_SUBTYPE,
     CONF_LINK_RGB_CT,
@@ -396,6 +397,14 @@ class TasmotaLight(TasmotaAvailability, TasmotaEntity):
             commands.append((command, argument))
 
         await send_commands(self._mqtt_client, self._cfg.command_topic, commands)
+
+    async def wakeup(self, **kwargs: Any) -> None:
+        """Wake up the light."""
+        payload = kwargs.get("dimmer", "")
+        await self._mqtt_client.publish(
+            self._cfg.command_topic + COMMAND_WAKEUP,
+            payload,
+        )
 
     def _calculate_speed(self, state: bool, attributes: dict[str, Any]) -> float:
         # Calculate speed:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = open("README.md").read()
 
 setup(
     name="HATasmota",
-    version="0.6.1",
+    version="0.6.2",
     license="MIT",
     url="https://github.com/emontnemery/hatasmota",
     author="",


### PR DESCRIPTION
Tasmota has a native wakeup feature. Currently this is only accessible via a light effect which doesn't actually work since HA always turns on the light before applying an effect, which negates the wake up effect since it turns on to full brightness (or whatever the brightness was before it was turned off). This feature allows me to implement a custom tasmota wake_up service which I'm busy with [here](https://github.com/BrendanBall/home-assistant-core/tree/tasmota_add_wake_up_service).
 See https://tasmota.github.io/docs/Commands/#light for details:
> Wakeup: Start wake up sequence from OFF to stored Dimmer value0..100 = Start wake up sequence from OFF to provided Dimmer value
> WakeupDuration: 1..3000 = set wake up duration in seconds

Unfortunately WakeupDuration has to be set prior to calling Wakeup. It would be great if this was another parameter part of Wakeup so that it could easily be added as another parameter in the HA tasmota service, although I guess this could be implemented with Backlog.

Let me know what you think. 





