### PR TITLE
Bump minimum Python version to 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v1
         with:
-          python-version: 3.11
+          python-version: 3.13
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.11
+python_version = 3.13
 plugins = pydantic.mypy
 show_error_codes = true
 local_partial_types = true

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.13',
 )


### PR DESCRIPTION
Bump minimum Python version to 3.13, same as required by Home Assistant Core