### PR TITLE
Camera: Correct the discovery message

### DIFF
--- a/hatasmota/discovery.py
+++ b/hatasmota/discovery.py
@@ -344,7 +344,7 @@ def get_camera_entities(
     camera_entities: list[tuple[TasmotaCameraConfig | None, DiscoveryHashType]] = []
 
     entity = None
-    discovery_hash = (discovery_msg[CONF_MAC], "cam", "cam", 0)
+    discovery_hash = (discovery_msg[CONF_MAC], "camera", "camera", 0)
     if CONF_CAM in discovery_msg and discovery_msg[CONF_CAM]:
         entity = TasmotaCameraConfig.from_discovery_message(discovery_msg, "camera")
     camera_entities.append((entity, discovery_hash))


### PR DESCRIPTION
The entity removal logic in `components/tasmota/discovery.py` uses a concatenation of platform string.

Since the discovery message uses 'cam' instead of 'camera', it cannot find the entity ID during the removal.
It also failed the `test_discovery_device_remove` test because of this.
Thus, if the tasmota device stops adding `"cam":1` in the discovery message, home-assistant keeps seeing the camera entity. This change corrects that.