### PR TITLE
New feat: start firmware updates through updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# hatasmota
+# HATasmota
+
+Python module to interact with Tasmota devices via MQTT.
+
+## Features
+
+- Support for Tasmota discovery
+- Support for various Tasmota components (Switch, Light, Sensor, etc.)
+- **Firmware Update Support**: Update Tasmota firmware via MQTT (Status 2 / Upgrade).
+
+## Usage
+
+See Home Assistant Tasmota integration for usage.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,42 @@
 # HATasmota
 
-Python module to interact with Tasmota devices via MQTT.
+HATasmota is a Python module designed to interact with [Tasmota](https://tasmota.github.io/docs/) devices via MQTT. It provides a structured way to handle device discovery, status monitoring, and control.
+
+This library is primarily used by the [Home Assistant Tasmota integration](https://www.home-assistant.io/integrations/tasmota/).
 
 ## Features
 
-- Support for Tasmota discovery
-- Support for various Tasmota components (Switch, Light, Sensor, etc.)
-- **Firmware Update Support**: Update Tasmota firmware via MQTT (Status 2 / Upgrade).
+- **Tasmota Device Discovery**: Automatic identification of Tasmota devices on the network.
+- **Component Support**: Broad support for various Tasmota components, including Relays, Sensors, Shutters, Fans, and Triggers.
+- **Firmware Updates**: Manage Tasmota firmware updates via MQTT using the `Status 2` and `Upgrade` commands.
 
-## Usage
+## Firmware Updates
 
-See Home Assistant Tasmota integration for usage.
+HATasmota supports updating official Tasmota firmware. To ensure stability, the integration filters builds to ensure only safe, official binaries are used for auto-updates.
+
+### Supported Versions
+
+Official stable releases are supported. The integration identifies "Stock" builds based on their variant name in the version string.
+
+| Build Type | Variants / Patterns | Status |
+| :--- | :--- | :---: |
+| **Standard** | `tasmota`, `tasmota32`, `tasmota32c3`, etc. | ✅ Supported |
+| **Localized** | `tasmota-DE`, `tasmota-PL`, `tasmota-FR`, etc. | ✅ Supported |
+| **Feature Set** | `sensors`, `allsensors`, `lite`, `knx`, `matter`, `zbbridge`, `zigbee`, `br`, `ircube`, `displays`, `mega`, `platinum`, `titanium` | ✅ Supported |
+| **Minimal** | `minimal`, `tasmota-minimal` | ❌ Excluded |
+| **Battery** | `battery`, `tasmota-battery` | ❌ Excluded |
+| **Custom** | Any custom name, e.g., `(my-custom-build)` | ❌ Excluded |
+
+### Excluded Builds (Safety First)
+
+The "Excluded" builds in the table above are withheld from the update check to prevent device instability:
+
+- **Minimal Builds**: `minimal`, `tasmota-minimal`. These are transitional builds used only during the update process and should never be the final running firmware.
+- **Battery Builds**: `battery`, `tasmota-battery`. Highly specialized builds for low-power sensors that should be managed manually.
+- **Custom Builds**: Any version with a custom variant name (e.g., `(my-custom-build)`).
+
+## More Information
+
+For more details on how to use Tasmota with Home Assistant, please refer to the official documentation:
+
+👉 [Home Assistant Tasmota Integration](https://www.home-assistant.io/integrations/tasmota/)

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Official stable releases are supported. The integration identifies "Stock" build
 
 | Build Type | Variants / Patterns | Status |
 | :--- | :--- | :---: |
-| **Standard** | `tasmota`, `tasmota32`, `tasmota32c3`, etc. | ✅ Supported |
-| **Localized** | `tasmota-DE`, `tasmota-PL`, `tasmota-FR`, etc. | ✅ Supported |
-| **Feature Set** | `sensors`, `allsensors`, `lite`, `knx`, `matter`, `zbbridge`, `zigbee`, `br`, `ircube`, `displays`, `mega`, `platinum`, `titanium` | ✅ Supported |
+| **Standard** | `tasmota` (incl. `4M`), `tasmota32` family (S2, S3, C2, C3, C5, C6, P4, solo1) | ✅ Supported |
+| **Localized** | `tasmota-AD` to `tasmota-VN`, `tasmota32-AD` to `tasmota32-VN` | ✅ Supported |
+| **Feature Set** | `sensors`, `display`, `ir`, `knx`, `zbbridge`, `zigbee`, `lite`, `bluetooth`, `lvgl`, `nspanel`, `webcam`, `zbbridgepro` | ✅ Supported |
 | **Minimal** | `minimal`, `tasmota-minimal` | ❌ Excluded |
-| **Battery** | `battery`, `tasmota-battery` | ❌ Excluded |
+| **Legacy** | Versions older than `9.1.0` | ❌ Excluded |
 | **Custom** | Any custom name, e.g., `(my-custom-build)` | ❌ Excluded |
 
 ### Excluded Builds (Safety First)
@@ -32,11 +32,10 @@ Official stable releases are supported. The integration identifies "Stock" build
 The "Excluded" builds in the table above are withheld from the update check to prevent device instability:
 
 - **Minimal Builds**: `minimal`, `tasmota-minimal`. These are transitional builds used only during the update process and should never be the final running firmware.
-- **Battery Builds**: `battery`, `tasmota-battery`. Highly specialized builds for low-power sensors that should be managed manually.
 - **Custom Builds**: Any version with a custom variant name (e.g., `(my-custom-build)`).
 
 ## More Information
 
 For more details on how to use Tasmota with Home Assistant, please refer to the official documentation:
 
-👉 [Home Assistant Tasmota Integration](https://www.home-assistant.io/integrations/tasmota/)
+[Home Assistant Tasmota Integration](https://www.home-assistant.io/integrations/tasmota/)

--- a/hatasmota/__init__.py
+++ b/hatasmota/__init__.py
@@ -1,4 +1,5 @@
 """HATasmota."""
+
 from .const import COMMAND_UPGRADE
 from .update import TasmotaUpdate, TasmotaUpdateConfig
 

--- a/hatasmota/__init__.py
+++ b/hatasmota/__init__.py
@@ -1,1 +1,9 @@
 """HATasmota."""
+from .const import COMMAND_UPGRADE
+from .update import TasmotaUpdate, TasmotaUpdateConfig
+
+__all__ = [
+    "COMMAND_UPGRADE",
+    "TasmotaUpdate",
+    "TasmotaUpdateConfig",
+]

--- a/hatasmota/__init__.py
+++ b/hatasmota/__init__.py
@@ -1,10 +1,11 @@
 """HATasmota."""
 
 from .const import COMMAND_UPGRADE
-from .update import TasmotaUpdate, TasmotaUpdateConfig
+from .update import TasmotaUpdate, TasmotaUpdateConfig, is_stock_build
 
 __all__ = [
     "COMMAND_UPGRADE",
     "TasmotaUpdate",
     "TasmotaUpdateConfig",
+    "is_stock_build",
 ]

--- a/hatasmota/config_validation.py
+++ b/hatasmota/config_validation.py
@@ -11,7 +11,6 @@ T = TypeVar("T")  # pylint: disable=invalid-name
 
 bit = vol.All(vol.Coerce(int), vol.Range(min=0, max=1))
 
-
 positive_int = vol.All(  # pylint: disable=invalid-name
     vol.Coerce(int), vol.Range(min=0)
 )

--- a/hatasmota/const.py
+++ b/hatasmota/const.py
@@ -19,6 +19,7 @@ COMMAND_SHUTTER_POSITION: Final = "ShutterPosition"
 COMMAND_SHUTTER_STOP: Final = "ShutterStop"
 COMMAND_SHUTTER_TILT: Final = "ShutterTilt"
 COMMAND_SPEED: Final = "Speed2"
+COMMAND_UPGRADE: Final = "Upgrade"
 COMMAND_WHITE: Final = "White"
 
 CONF_BUTTON: Final = "btn"

--- a/hatasmota/discovery.py
+++ b/hatasmota/discovery.py
@@ -506,7 +506,6 @@ def get_update_entities(
     return update_entities
 
 
-
 def get_entities_for_platform(
     discovery_msg: dict, platform: str
 ) -> list[tuple[TasmotaEntityConfig | None, DiscoveryHashType]]:

--- a/hatasmota/discovery.py
+++ b/hatasmota/discovery.py
@@ -80,6 +80,7 @@ from .switch import (
     TasmotaSwitchTriggerConfig,
 )
 from .trigger import TasmotaTrigger, TasmotaTriggerConfig
+from .update import TasmotaUpdate, TasmotaUpdateConfig
 from .utils import discovery_topic_get_mac, discovery_topic_is_device_config
 
 TASMOTA_OPTIONS_SCHEMA = vol.Schema(
@@ -487,6 +488,25 @@ def get_status_sensor_entities(
     return status_sensor_entities
 
 
+def get_update_entities(
+    discovery_msg: dict,
+) -> list[tuple[TasmotaUpdateConfig, DiscoveryHashType]]:
+    """Generate Update sensors."""
+    update_entities: list[tuple[TasmotaUpdateConfig, DiscoveryHashType]] = []
+
+    entity = TasmotaUpdateConfig.from_discovery_message(discovery_msg)
+    discovery_hash = (
+        discovery_msg[CONF_MAC],
+        "update",
+        "update",
+        "firmware",
+    )
+    update_entities.append((entity, discovery_hash))
+
+    return update_entities
+
+
+
 def get_entities_for_platform(
     discovery_msg: dict, platform: str
 ) -> list[tuple[TasmotaEntityConfig | None, DiscoveryHashType]]:
@@ -506,6 +526,8 @@ def get_entities_for_platform(
         entities.extend(get_status_sensor_entities(discovery_msg))
     elif platform == "switch":
         entities.extend(get_switch_entities(discovery_msg))
+    elif platform == "update":
+        entities.extend(get_update_entities(discovery_msg))
     return entities
 
 
@@ -536,6 +558,8 @@ def get_entity(
         return TasmotaStatusSensor(config=config, mqtt_client=mqtt_client)
     if platform == "switch":
         return TasmotaRelay(config=config, mqtt_client=mqtt_client)
+    if platform == "update":
+        return TasmotaUpdate(config=config, mqtt_client=mqtt_client)
     return None
 
 

--- a/hatasmota/sensor.py
+++ b/hatasmota/sensor.py
@@ -152,7 +152,6 @@ IGNORED_SENSORS = ["Time", "PN532", "RDM6300"]
 # SENSOR_VOLTAGE                  V               "ic":"mdi:alpha-v-circle-outline"
 # SENSOR_WEIGHT                   Kg              "ic":"mdi:scale"
 
-
 SENSOR_UNIT_MAP = {
     SENSOR_AMBIENT: LIGHT_LUX,
     SENSOR_BATTERY: PERCENTAGE,

--- a/hatasmota/update.py
+++ b/hatasmota/update.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import logging
 import re
-from dataclasses import dataclass
 from typing import Any
 
 from .const import COMMAND_BACKLOG, COMMAND_UPGRADE, CONF_DEEP_SLEEP, CONF_MAC

--- a/hatasmota/update.py
+++ b/hatasmota/update.py
@@ -1,0 +1,129 @@
+"""Tasmota update."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from .const import COMMAND_UPGRADE, CONF_DEEP_SLEEP, CONF_MAC
+from .entity import (
+    TasmotaAvailability,
+    TasmotaAvailabilityConfig,
+    TasmotaEntity,
+    TasmotaEntityConfig,
+)
+from .mqtt import ReceiveMessage
+from .utils import (
+    config_get_state_offline,
+    config_get_state_online,
+    get_topic_command,
+    get_topic_command_status,
+    get_topic_stat_status,
+    get_topic_tele_state,
+    get_topic_tele_will,
+    get_value_by_path,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class TasmotaUpdateConfig(TasmotaAvailabilityConfig, TasmotaEntityConfig):
+    """Tasmota Update configuration."""
+
+    poll_topic: str
+    state_topic: str
+    status_topic: str
+    command_topic: str
+
+    @classmethod
+    def from_discovery_message(cls, config: dict) -> TasmotaUpdateConfig:
+        """Instantiate from discovery message."""
+        return cls(
+            endpoint="update",
+            idx=None,
+            friendly_name=None,
+            mac=config[CONF_MAC],
+            platform="update",
+            poll_payload="2",
+            poll_topic=get_topic_command_status(config),
+            availability_topic=get_topic_tele_will(config),
+            availability_offline=config_get_state_offline(config),
+            availability_online=config_get_state_online(config),
+            deep_sleep_enabled=config[CONF_DEEP_SLEEP],
+            state_topic=get_topic_tele_state(config),
+            status_topic=get_topic_stat_status(config, 2),
+            command_topic=get_topic_command(config) + COMMAND_UPGRADE,
+        )
+
+
+class TasmotaUpdate(TasmotaAvailability, TasmotaEntity):
+    """Tasmota Update."""
+
+    _cfg: TasmotaUpdateConfig
+
+    def __init__(self, **kwds: Any):
+        """Initialize."""
+        self._sub_state: dict | None = None
+        super().__init__(**kwds)
+
+    async def update_firmware(self, url: str | None = None) -> None:
+        """Update firmware."""
+        payload = "1"
+        if url:
+            payload = url
+        await self._mqtt_client.publish(
+            self._cfg.command_topic,
+            payload,
+        )
+
+    async def subscribe_topics(self) -> None:
+        """Subscribe to topics."""
+
+        def state_message_received(msg: ReceiveMessage) -> None:
+            """Handle new MQTT state messages."""
+            if not self._on_state_callback:
+                return
+
+            try:
+                payload = json.loads(msg.payload)
+            except json.decoder.JSONDecodeError:
+                return
+
+            # Status 2: {"StatusFWR":{"Version":"12.3.1(tasmota)","BuildDateTime":"..."}}
+            # We look for StatusFWR.Version
+            version = get_value_by_path(payload, ["StatusFWR", "Version"])
+            if version:
+                self._on_state_callback(version)
+
+        availability_topics = self.get_availability_topics()
+        topics = {}
+        # Periodic state update (tele/STATE) - usually doesn't contain version
+        # but we might as well listen if we needed it. For now, we rely on polling Status 2.
+
+        # Polled state update (stat/STATUS2)
+        topics["status_topic"] = {
+            "event_loop_safe": True,
+            "topic": self._cfg.status_topic,
+            "msg_callback": state_message_received,
+        }
+
+        topics = {**topics, **availability_topics}
+
+        self._sub_state = await self._mqtt_client.subscribe(
+            self._sub_state,
+            topics,
+        )
+
+    async def unsubscribe_topics(self) -> None:
+        """Unsubscribe from all MQTT topics."""
+        self._sub_state = await self._mqtt_client.unsubscribe(self._sub_state)
+
+    async def poll_status(self) -> None:
+        """Poll for status."""
+        await self.subscribe_topics()
+        await self._mqtt_client.publish_debounced(
+            self._cfg.poll_topic, self._cfg.poll_payload
+        )

--- a/hatasmota/update.py
+++ b/hatasmota/update.py
@@ -42,6 +42,7 @@ OFFICIAL_VARIANTS = {
     "display",
     "zbbridge",
     "zigbee",
+    "4M",
     # ESP32 Family
     "tasmota32",
     "tasmota32solo1",

--- a/hatasmota/update.py
+++ b/hatasmota/update.py
@@ -70,6 +70,10 @@ def is_stock_build(version_str: str) -> bool:
     version_num_str = match.group("version")
     variant = match.group("variant")
 
+    # Normalize variant: versions >= 15.0 may prefix standard variants with 'release-'
+    if variant.startswith("release-"):
+        variant = variant[8:]
+
     # Safety check: Versions older than 9.1.0 require manual migration paths
     try:
         version_parts = tuple(int(p) for p in version_num_str.split("."))
@@ -88,14 +92,17 @@ def is_stock_build(version_str: str) -> bool:
 
     if variant in OFFICIAL_VARIANTS:
         return True
+
     # Localized language builds (e.g., tasmota-DE, tasmota32-DE)
     if re.match(r"^(tasmota|tasmota32)-[A-Z]{2}$", variant):
         return True
+
     # Prefixed official variants (e.g., tasmota-sensors, tasmota32-display)
     if variant.startswith("tasmota-") and variant[8:] in OFFICIAL_VARIANTS:
         return True
     if variant.startswith("tasmota32-") and variant[10:] in OFFICIAL_VARIANTS:
         return True
+
     return False
 
 

--- a/hatasmota/update.py
+++ b/hatasmota/update.py
@@ -186,13 +186,12 @@ class TasmotaUpdate(TasmotaAvailability, TasmotaEntity):
             # Status 2: {"StatusFWR":{"Version":"12.3.1(tasmota)","BuildDateTime":"..."}}
             # We look for StatusFWR.Version
             if version := get_value_by_path(payload, ["StatusFWR", "Version"]):
-                if is_stock_build(version):
-                    self._on_state_callback(version)
-                else:
+                self._on_state_callback(version)
+                if not is_stock_build(version):
                     match = VERSION_VARIANT_PATTERN.match(version)
                     variant = match.group("variant") if match else "unknown"
                     _LOGGER.debug(
-                        "[%s] Custom firmware build detected (variant: %s). Skipping update check.",
+                        "[%s] Custom firmware build detected (variant: %s).",
                         self._cfg.mac,
                         variant,
                     )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = open("README.md").read()
 
 setup(
     name="HATasmota",
-    version="0.10.1",
+    version="0.10.2",
     license="MIT",
     url="https://github.com/emontnemery/hatasmota",
     author="",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup, find_packages  # type: ignore[import-untyped]
 
-
 long_description = open("README.md").read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages  # type: ignore[import-untyped]
 
 
 long_description = open("README.md").read()
@@ -26,5 +26,5 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires='>=3.13',
+    python_requires=">=3.13",
 )


### PR DESCRIPTION
Continuation of PR #317

This PR is to extend the functionality for Homeassistant to detect available tasmota firmware updates and start them remotly. See #151 

The HA Integration also needed to be extended, this work is being done here for a future PR to the core repo: 
https://github.com/FaserF/core/tree/new-feat-tasmota-fw-update

Code has been validated and tested. 
To test the functionality I have created a new repository: https://github.com/FaserF/ha-tasmota-fwupdate 
The new pip module is directly implemented there to handle version conflicts.

More informations about what the final goal should be: 
https://community.home-assistant.io/t/support-firmware-update-in-tasmota-integration/410167
https://github.com/arendst/Tasmota/discussions/15480

<img width="614" height="1248" alt="image" src="https://github.com/user-attachments/assets/9b268b9c-01a5-4ffe-95bd-48bf02d573b8" />

<img width="596" height="530" alt="image" src="https://github.com/user-attachments/assets/eb5f51b4-41fe-4333-9e96-7e2a10b0fdb1" />
